### PR TITLE
Legacy Cleanup: ClearCart

### DIFF
--- a/xlsws_includes/cart.php
+++ b/xlsws_includes/cart.php
@@ -301,7 +301,7 @@ class xlsws_cart extends xlsws_index {
 	 * @return none
 	 */
 	protected function clearCart($strFormId, $strControlId, $strParameter) {
-			Cart::clear_cart();
+			Cart::ClearCart();
 			_xls_display_msg(_sp("Your cart content has been cleared"));
 			return;
 	}


### PR DESCRIPTION
This is just a small bit of legacy code I noticed while looking through some logs here.

`grep -r 'clear_cart' *` shows that this was the only call remaining of clear_cart, so it likely can be removed from the Cart class in the future.

Best Regards

-Jared
