### PR TITLE
Fix for GH-86

### DIFF
--- a/verify-img.php
+++ b/verify-img.php
@@ -31,6 +31,15 @@ $SECIMG_DIR='includes/securimage';
 
 define('__PREPEND_QUICKINIT__', true);
 require('includes/prepend.inc.php');
+
+// Ensure we load the database session storage object if needed
+if (_xls_get_conf('SESSION_HANDLER') == 'DB') {
+	QApplication::$ClassFile['xlssessionhandler'] =
+		__XLSWS_INCLUDES__ .
+		'/core/session/XLSDBSessionHandler.class.php';
+	XLSSessionHandler::$CollectionOverridePhp = true;
+}
+
 QApplication::$EnableSession = true;
 QApplication::InitializeSession();
 $sessname = QApplication::$SessionName;


### PR DESCRIPTION
I was able to reproduce this on my dev environment with PHP 5.2.17.

It came down to not loading the DB session, if needed.

Although I suppose defining something along the lines of **SECURIMAGE_INIT** and applying the appropriate logic to auto_includes would work just a well, most session start logic was already hard coded in this file so I followed suit in hard coding the DB session logic.
