### PR TITLE
Compatibility fix & OpenSSL check

### DIFF
--- a/install.php
+++ b/install.php
@@ -1075,7 +1075,8 @@ EOT;
 				$checked['MCrypt Encryption Library']= isset($phpinfo['mcrypt']) ? "pass" : "fail";
 				$checked['Session use_only_cookies must be turned Off']= ($phpinfo['session']['session.use_only_cookies']=="Off" ? "pass" : "fail");
 				$checked['Soap Library']= ($phpinfo['soap']['Soap Client']=="enabled" ? "pass" : "fail");
-			
+				$checked['OpenSSL']= ($phpinfo['openssl']['OpenSSL support']=="enabled" ? "pass" : "fail");
+
 				//Check php.ini settings
 				$checked['allow_call_time_pass_reference in Php.ini must be turned On']=($phpinfo['Core']['allow_call_time_pass_reference']=="On" ? "pass" : "fail");
 				$checked['magic_quotes_gpc in Php.ini must be turned Off']=($phpinfo['Core']['magic_quotes_gpc']=="Off" ? "pass" : "fail");


### PR DESCRIPTION
Here's two commits to install.php for issues that I've come across today:

1) Ensure we reference a variable and not a function return for PHP 5.4 compatibility.
2) Check for OpenSSL extension, required by (at least) Fedex shipping module.

Best Regards

Jared Kazimir
