### PR TITLE
Update skeleton.css

### DIFF
--- a/templates/brooklyn/css/skeleton.css
+++ b/templates/brooklyn/css/skeleton.css
@@ -48,7 +48,7 @@ for comparison is skeleton_original.css
 .container .six.columns                     { width: 356px; }
 .container .seven.columns                   { width: 417px; }
 .container .eight.columns                   { width: 478px; }
-.container .nine.columns                    { width: 539; }
+.container .nine.columns                    { width: 539px; }
 .container .ten.columns                     { width: 600px; }
 .container .eleven.columns                  { width: 661px; }
 .container .twelve.columns                  { width: 722px; }


### PR DESCRIPTION
Units (px) were missing from the .nine class, causing any layouts using a nine column block to not render properly.
