### PR TITLE
Fixed issues with png transparency.

### DIFF
--- a/core/protected/extensions/image/drivers/Image_GD_Driver.php
+++ b/core/protected/extensions/image/drivers/Image_GD_Driver.php
@@ -347,34 +347,16 @@ class Image_GD_Driver extends Image_Driver {
 	 */
 	protected function imagecreatetransparent($width, $height)
 	{
-		if (self::$blank_png === NULL)
-		{
-			// Decode the blank PNG if it has not been done already
-			self::$blank_png = imagecreatefromstring(base64_decode
-			(
-				'iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29'.
-				'mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADqSURBVHjaYvz//z/DYAYAAcTEMMgBQAANegcCBN'.
-				'CgdyBAAA16BwIE0KB3IEAADXoHAgTQoHcgQAANegcCBNCgdyBAAA16BwIE0KB3IEAADXoHAgTQoHcgQ'.
-				'AANegcCBNCgdyBAAA16BwIE0KB3IEAADXoHAgTQoHcgQAANegcCBNCgdyBAAA16BwIE0KB3IEAADXoH'.
-				'AgTQoHcgQAANegcCBNCgdyBAAA16BwIE0KB3IEAADXoHAgTQoHcgQAANegcCBNCgdyBAAA16BwIE0KB'.
-				'3IEAADXoHAgTQoHcgQAANegcCBNCgdyBAgAEAMpcDTTQWJVEAAAAASUVORK5CYII='
-			));
-
-			// Set the blank PNG width and height
-			self::$blank_png_width = imagesx(self::$blank_png);
-			self::$blank_png_height = imagesy(self::$blank_png);
-		}
-
-		$img = imagecreatetruecolor($width, $height);
-
-		// Resize the blank image
-		imagecopyresized($img, self::$blank_png, 0, 0, 0, 0, $width, $height, self::$blank_png_width, self::$blank_png_height);
-
-		// Prevent the alpha from being lost
-		imagealphablending($img, FALSE);
-		imagesavealpha($img, TRUE);
-
-		return $img;
+		$image_resized = imagecreatetruecolor( $width, $height );
+		// Turn off transparency blending (temporarily)
+		imagealphablending($image_resized, false);
+		// Create a new transparent color for image
+		$color = imagecolorallocatealpha($image_resized, 0, 0, 0, 127);
+		// Completely fill the background of the new image with allocated color.
+		imagefill($image_resized, 0, 0, $color);
+		// Restore transparency blending
+		imagesavealpha($image_resized, true);
+		return $image_resized;
 	}
 
 } // End Image GD Driver

--- a/core/protected/models/Images.php
+++ b/core/protected/models/Images.php
@@ -258,7 +258,10 @@ class Images extends BaseImages
 	public function SaveImageData($strName, $blbImage) {
 
 			$this->DeleteImage();
-
+			
+			imagealphablending($blbImage, false);
+			imagesavealpha($blbImage, TRUE);
+			
 			$strPath = Images::GetImagePath($strName);
 			$arrPath = mb_pathinfo($strPath);
 


### PR DESCRIPTION
We noticed that image transparency was being lost when uploading images from LightSpeed, despite the fact that IMAGE_BACKGROUND was null. It turns out that it was being lost in two ways: first, whenever Images::SaveImageData() would save the $blbImage to disk, and second whenever Image_GD_Driver attempted to create a transparent blank image with imagecreatetransparent().

SaveImageData() needs to run imagealphablending() and imagesavealpha() on the $blbImage before saving it.

Image_GD_Driver's original imagecreatetransparent() method did not create a transparent image at all, it was black. We replaced it with a different version.
